### PR TITLE
fix pip install pathing => scripts folder

### DIFF
--- a/ToolsAcct/code-pipeline.yaml
+++ b/ToolsAcct/code-pipeline.yaml
@@ -113,7 +113,7 @@ Resources:
               commands:
                 - printenv
                 - ls -R
-                - pip install -r requirements.txt -t "$PWD"
+                - pip install -r scripts/requirements.txt -t "$PWD"
             build:
               commands:
                 - aws cloudformation package --template-file lambda-cloudformation.yaml --s3-bucket $S3Bucket --s3-prefix sample-lambda/codebuild --output-template-file samtemplate.yaml


### PR DESCRIPTION
Just tiny pathing fix to make the buildspec.yml work as intended when running pip install. otherwise this fails in codebuild when looking for the requirements.txt file (not in root but in scripts folder)

ps. this only relates to this working end to end with the sample-lambda github repo :)

thanks and great work!