### PR TITLE
account ID's are Strings, not numbers

### DIFF
--- a/ToolsAcct/pre-reqs.yaml
+++ b/ToolsAcct/pre-reqs.yaml
@@ -11,13 +11,13 @@ Description: Creates a CMK in KMS and grants access to other accounts
 Parameters:
   DevAccount:
     Description: AWS AccountNumber for dev
-    Type: Number
+    Type: String
   TestAccount:
     Description: AWS AccountNumber for test
-    Type: Number
+    Type: String
   ProductionAccount:
     Description: AWS AccountNumber for production
-    Type: Number
+    Type: String
   ProjectName:
     Description: Name of the Project
     Type: String


### PR DESCRIPTION
*Issue #, if available:* 001

*Description of changes:* Treating them like numbers creates problems for accounts that start with leading zeroes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
